### PR TITLE
Feature/update association player

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,5 +1,8 @@
 class Album < ApplicationRecord
   belongs_to :player
 
+  has_many :players_albums
+  has_many :players, through: :players_albums
+
   validates_presence_of :name
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,5 +1,6 @@
 class Player < ApplicationRecord
-  has_many :albums
+  has_many :players_albums
+  has_many :albums,  through: :players_albums
 
   validates_presence_of :name
 end

--- a/app/models/players_album.rb
+++ b/app/models/players_album.rb
@@ -1,0 +1,4 @@
+class PlayersAlbum < ApplicationRecord
+  belongs_to :player
+  belongs_to :album
+end

--- a/db/migrate/20220612180310_create_players_albums.rb
+++ b/db/migrate/20220612180310_create_players_albums.rb
@@ -1,0 +1,10 @@
+class CreatePlayersAlbums < ActiveRecord::Migration[5.2]
+  def change
+    create_table :players_albums do |t|
+      t.references :player, foreign_key: true
+      t.references :album, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220612185725_update_player_association.rb
+++ b/db/migrate/20220612185725_update_player_association.rb
@@ -1,0 +1,7 @@
+Rails.application.load_tasks
+
+class UpdatePlayerAssociation < ActiveRecord::Migration[5.2]
+  def change
+    Rake::Task["update_association:albums"].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_12_180310) do
+ActiveRecord::Schema.define(version: 2022_06_12_185725) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_02_203647) do
+ActiveRecord::Schema.define(version: 2022_06_12_180310) do
 
   create_table "albums", force: :cascade do |t|
     t.string "name"
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 2018_08_02_203647) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "players_albums", force: :cascade do |t|
+    t.integer "player_id"
+    t.integer "album_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["album_id"], name: "index_players_albums_on_album_id"
+    t.index ["player_id"], name: "index_players_albums_on_player_id"
   end
 
 end

--- a/lib/tasks/update_association.rake
+++ b/lib/tasks/update_association.rake
@@ -1,7 +1,11 @@
 namespace :update_association do
+
+  desc "Update Association: player to players"
   task albums: :environment do
     Album.all.each do |album|
       PlayersAlbum.find_or_create_by(album_id: album.id, player_id: album.player.id)
+      album.player = nil
+      album.save
     end
   end
 end

--- a/lib/tasks/update_association.rake
+++ b/lib/tasks/update_association.rake
@@ -1,0 +1,7 @@
+namespace :update_association do
+  task albums: :environment do
+    Album.all.each do |album|
+      PlayersAlbum.find_or_create_by(album_id: album.id, player_id: album.player.id)
+    end
+  end
+end

--- a/test/fixtures/players_albums.yml
+++ b/test/fixtures/players_albums.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  player: one
+  album: one
+
+two:
+  player: two
+  album: two

--- a/test/models/players_album_test.rb
+++ b/test/models/players_album_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PlayersAlbumTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### Descrição

Esse PR Converte o relacionamento entre Albuns e Player de 1:N para N:N
Ele basicamente cria as estruturas e possui uma rake que no momento está rodando de uma própria migration, evitando inverter a ordem entre migrations e tasks.

Também possui uma task que atualiza as informações para a nova estrutura de dados, que roda dentro de uma migration

